### PR TITLE
Änderungsvorschlag Zitatesammlung

### DIFF
--- a/app/assets/stylesheets/threads.css.scss
+++ b/app/assets/stylesheets/threads.css.scss
@@ -334,6 +334,7 @@ a.thread-forum-plate {
 
 @media only screen and (min-width: 35em) {
   .thread > header > .thread-icons {
+    position:relative;
     position:sticky;
   }
 

--- a/app/views/cites/_cite.html.erb
+++ b/app/views/cites/_cite.html.erb
@@ -35,10 +35,10 @@ end
           </span>
         <% end %>
 
-        <%= cf_link_to cite.author, cite_path(cite) %>
+        <%= cf_link_to cite.author, cite.url %>
       </span>
 
-      <time datetime="<%= cite.cite_date.strftime("%FT%T%:z") %>"><%= cf_link_to l(cite.cite_date, format: uconf('date_format_date')), cite_path(cite) %></time>
+      <time datetime="<%= cite.cite_date.strftime("%FT%T%:z") %>"><%= cf_link_to l(cite.cite_date, format: uconf('date_format_date')), cite.url %></time>
     </div>
   </header>
 
@@ -63,7 +63,7 @@ end
   <div class="posting-content cite"><%= cite.to_html(@app_controller) %></div>
 
   <div>
-    <% unless cite.creator.blank? %><%= t('cites.created_by') %>
+    <% unless cite.creator.blank? %><%= t('cites.created_by_at') %>
       <span class="author">
         <% if not cite.creator_user_id.blank? %>
           <span class="registered-user">
@@ -74,6 +74,6 @@ end
           <span class="icon-message original-poster"><%= cite.creator %></span>
         <% end %>
       </span>
-    <% end %><% if not cite.url.blank? and not cite.message_id.blank? and @forums.include?(cite.message.forum) %><%= cf_link_to t('cites.source'), cite.url %><% end %>
+    <% end %><% if not cite.url.blank? and not cite.message_id.blank? and @forums.include?(cite.message.forum) %> <%= l(cite.created_at, format: uconf('date_format_date')) %><% end %>
   </div>
 </article>

--- a/config/locales/cites.de.yml
+++ b/config/locales/cites.de.yml
@@ -12,7 +12,7 @@ de:
     search: 'Zitatesammlung durchsuchen'
     read: 'Zitate lesen'
     destroy_cite: Zitat löschen
-    created_by: eingereicht von
+    created_by_at: 'eingereicht:'
     do_vote: über Zitate abstimmen
     do_read_cites: Zitate lesen
     no_votes_active: Zur Zeit sind keine Zitate zur Abstimmung aktiv.


### PR DESCRIPTION
siehe <https://forum.selfhtml.org/meta/2016/feb/8/position-quelle-bei-zitaten/1660434#m1660434>ff.

Es ist mir außerdem nicht gelungen, aus `<time><a>` `<a><time>` zu machen und der schon eingearbeitete PR ist auch wieder da.