### PR TITLE
fix typo 'tags_invalid' instead of 'tag_invalid'

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -23,7 +23,7 @@ module TagsHelper
           tag_obj = Tag.create(forum_id: forum.forum_id, tag_name: t)
 
           if tag_obj.tag_id.blank?
-            flash[:error] = t('messages.tag_invalid')
+            flash[:error] = t('messages.tags_invalid')
             raise ActiveRecord::Rollback.new
           end
 

--- a/config/locales/messages.de.yml
+++ b/config/locales/messages.de.yml
@@ -12,7 +12,7 @@ de:
     error_message:
       other: "%{count} Fehler verhinderten, dass dieser Beitrag gespeichert werden konnte:"
       one: "%{count} Fehler verhindert, dass dieser Beitrag gespeichert werden konnte:"
-    tags_invalid: Das Tag ist fehlerhaft.
+    tags_invalid: Ein Tag ist fehlerhaft.
     too_many_tags: "Sie dürfen nur maximal %{max_tags} Tags verwenden."
     not_enough_tags: 
       other: "Sie müssen mindestens %{count} Tags verwenden."


### PR DESCRIPTION
Vielleicht könnte man die Fehlermeldung auch noch etwas konkreter machen, z.B. welches Tag warum invalid ist.