### PR TITLE
Deleted unnecessary code and extended checks for newlines to single item lists. Also added a check if an unordered list is extended.

### DIFF
--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -1189,13 +1189,15 @@
               cursor = selected.start + 2 + prefix.length;
             }
             else {
+              prefix = e.getLeadingNewlines(content, selected);
+
               if(selected.text.indexOf('\n') < 0) {
                 chunk = selected.text;
 
-                e.replaceSelection('- ' + chunk);
+                e.replaceSelection(prefix + '- ' + chunk);
 
                 // Set the cursor
-                cursor = selected.start + 2;
+                cursor = selected.start + 2 + prefix.length;
               }
               else {
                 var list = selected.text.split('\n');
@@ -1205,11 +1207,10 @@
                   return '- ' + string;
                 });
 
-                var start = e.getLeadingNewlines(content, selected);
-                e.replaceSelection(start + list.join('\n'));
+                e.replaceSelection(prefix + list.join('\n'));
 
                 // Set the cursor
-                cursor = selected.start + 2 + start.length;
+                cursor = selected.start + 2 + prefix.length;
               }
             }
 
@@ -1249,13 +1250,15 @@
               cursor = selected.start + 3 + prefix.length;
             }
             else {
+              prefix = e.getLeadingNewlines(content, selected);
+
               if(selected.text.indexOf('\n') < 0) {
                 chunk = selected.text;
 
-                e.replaceSelection('1. ' + chunk);
+                e.replaceSelection(prefix + '1. ' + chunk);
 
                 // Set the cursor
-                cursor = selected.start + 3;
+                cursor = selected.start + 3 + prefix.length;
               }
               else {
                 var list = selected.text.split('\n');
@@ -1265,11 +1268,10 @@
                   return (index + 1) + '. ' + string;
                 });
 
-                var start = e.getLeadingNewlines(content, selected);
-                e.replaceSelection(start + list.join('\n'));
+                e.replaceSelection(prefix + list.join('\n'));
 
                 // Set the cursor
-                cursor = selected.start + 3 + start.length;
+                cursor = selected.start + 3 + prefix.length;
               }
             }
 

--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -63,6 +63,7 @@
 
     constructor: Markdown,
 
+
     __alterButtons: function(name, alter) {
       var handler = this.$handler,
           isAll = (name == 'all'),
@@ -146,6 +147,7 @@
       return container;
     },
 
+
     __setListener: function() {
       // Set size and resizable Properties
       var hasRows = typeof this.$textarea.attr('rows') !== 'undefined',
@@ -169,7 +171,6 @@
       // Re-attach markdown data
       this.$textarea.data('markdown', this);
     },
-
 
 
     __handle: function(e) {
@@ -203,7 +204,7 @@
       var messages = $.fn.markdown.messages,
           language = this.$options.language;
       if(
-        typeof messages !== 'undefined' &&
+          typeof messages !== 'undefined' &&
           typeof messages[language] !== 'undefined' &&
           typeof messages[language][string] !== 'undefined'
       ) {
@@ -217,10 +218,11 @@
       return typeof src == 'object' ? src[this.$options.iconlibrary] : src;
     },
 
-    __beginningOfLine: function(content, sel) {
-      var c = content.substr(sel.start - 1, 1);
-      return (c == "\n");
+
+    __isBeginningOfLine: function(content, selection) {
+      return (selection.start === 0) || (content.substr(selection.start - 1, 1) === '\n');
     },
+
 
     __previousLineIsList: function(content, sel, rx) {
       var i, c;
@@ -1181,7 +1183,7 @@
               if(!isExtension) {
                 prefix += '\n';
               }
-              if(!e.__beginningOfLine(content, selected)) {
+              if(!e.__isBeginningOfLine(content, selected)) {
                 prefix += '\n';
               }
 
@@ -1242,10 +1244,10 @@
               chunk = e.__localize('list text here');
 
               if(!e.__previousLineIsList(content, selected, /\d/)) {
-                prefix += "\n";
+                prefix += '\n';
               }
-              if(!e.__beginningOfLine(content, selected)) {
-                prefix += "\n";
+              if(!e.__isBeginningOfLine(content, selected)) {
+                prefix += '\n';
               }
 
               e.replaceSelection(prefix + '1. ' + chunk);

--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -1170,18 +1170,19 @@
           callback: function(e) {
             // Prepend/Give - surround the selection
             var chunk, cursor, selected = e.getSelection(),
-                content = e.getContent(), prefix = "";
+                content = e.getContent(), prefix = '',
+                isExtension = e.__previousLineIsList(content, selected, /-/);
 
             // transform selection and set the cursor into chunked text
             if(selected.length === 0) {
               // Give extra word
               chunk = e.__localize('list text here');
 
-              if(!e.__previousLineIsList(content, selected, /-/)) {
-                prefix += "\n";
+              if(!isExtension) {
+                prefix += '\n';
               }
               if(!e.__beginningOfLine(content, selected)) {
-                prefix += "\n";
+                prefix += '\n';
               }
 
               e.replaceSelection(prefix + '- ' + chunk);
@@ -1189,7 +1190,9 @@
               cursor = selected.start + 2 + prefix.length;
             }
             else {
-              prefix = e.getLeadingNewlines(content, selected);
+              if(!isExtension) {
+                prefix = e.getLeadingNewlines(content, selected);
+              }
 
               if(selected.text.indexOf('\n') < 0) {
                 chunk = selected.text;

--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -1198,9 +1198,7 @@
                 cursor = selected.start + 2;
               }
               else {
-                var list = [];
-
-                list = selected.text.split('\n');
+                var list = selected.text.split('\n');
                 chunk = list[0];
 
                 list = list.map(function(string) {
@@ -1260,9 +1258,7 @@
                 cursor = selected.start + 3;
               }
               else {
-                var list = [];
-
-                list = selected.text.split('\n');
+                var list = selected.text.split('\n');
                 chunk = list[0];
 
                 list = list.map(function(string, index) {


### PR DESCRIPTION
The first commit deletes empty arrays created just to feed the garbage collection:

    var list = [];
    list = selected.text.split('\n');

The method split will always return an array, so the variable `list` will be assigned an array anyway.

The second commit includes checks for newlines for the case of a list containing just one element. Until now, there are no newlines added, which can prevent a list to be rendered.

    text
    listitem -> mark and push button to add list syntax

Since selections containing newlines and selections without newline are treated within the same conditional branch, we only need a single call to `getLeadingNewlines` to cover both. I also deleted the variable `start`, because a variable `prefix` is declared at the top of each function creating list syntax.

The third commit includes a check whether an unordered list is extending another list.

    - listitem
    - listitem
    listitem
    listitem

Consider the list above. If you now mark the last two items and push the button to add bullets, no newlines will be added, so the existing list will just be extended.

I did some testing and it seems to behave as intended, but I recommend to do at least some quick tests by yourself before merging.