### PR TITLE
Conditionally include tildes instead of backticks.

### DIFF
--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -1292,8 +1292,7 @@
           },
           callback: function(e) {
             // Give/remove ** surround the selection
-            var chunk, cursor, selected = e.getSelection(),
-                content = e.getContent();
+            var lang, chunk, cursor, prefix, selected = e.getSelection(), content = e.getContent();
 
             if(selected.length === 0) {
               // Give extra word
@@ -1314,22 +1313,32 @@
               e.replaceSelection(chunk);
               cursor = selected.start - 1;
             }
-            else if(chunk.indexOf('\n') > -1) {
-              var lang = window.prompt(t('code_lang'));
+            else if(!selected.length && content.substr(selected.start - 2, 2) === '\n\n') {
+              lang = window.prompt(t('code_lang'));
 
               if((lang && lang.length > 20) || lang === null) {
                 return;
               }
 
-              var start = e.getLeadingNewlines(content, selected),
-                  end = (content.substr(selected.end, 1) === '\n') ? '' : '\n';
-
-              e.replaceSelection(start + '~~~' + (lang || "") + '\n' + chunk + '\n~~~' + end);
-              cursor = selected.start + start.length + 4 + lang.length;
+              e.replaceSelection('~~~' + (lang || '') + '\n' + chunk + '\n~~~\n');
+              cursor = selected.start + 4 + lang.length;
             }
             else {
-              e.replaceSelection('`' + chunk + '`');
-              cursor = selected.start + 1;
+              if(chunk.indexOf('\n') > -1) {
+                lang = window.prompt(t('code_lang'));
+
+                if((lang && lang.length > 20) || lang === null) {
+                  return;
+                }
+
+                prefix = e.getLeadingNewlines(content, selected);
+                e.replaceSelection(prefix + '~~~' + (lang || "") + '\n' + chunk + '\n~~~\n');
+                cursor = selected.start + prefix.length + 4 + lang.length;
+              }
+              else {
+                e.replaceSelection('`' + chunk + '`');
+                cursor = selected.start + 1;
+              }
             }
 
             // Set the cursor


### PR DESCRIPTION
This should do the trick. If there's nothing selected and the cursor position is preceded by two newlines, then tildes for a code block will be included instead of backticks for inline code. Nevertheless, I do recommend some further tests, because I encountered a really weird bug doing my own tests:

Everything seemed to work as intended, but at some point, when I selected text that definitely included newlines, pushing the button resulted in only the first line being wrapped in backticks, with the rest of the selected text being ignored.

I really can't explain this behavior and was not able to consistently reproduce it.