### PR TITLE
CSS für das überarbeitete Antwortfeld

### DIFF
--- a/app/assets/javascripts/markdown/bootstrap-markdown.js
+++ b/app/assets/javascripts/markdown/bootstrap-markdown.js
@@ -983,7 +983,7 @@
           name: 'cmdBold',
           hotkey: 'Ctrl+B',
           title: 'Bold',
-          btnText: 'Bold',
+          // btnText: 'Bold',
           icon: {
             glyph: 'glyphicon glyphicon-bold',
             fa: 'fa fa-bold',
@@ -1019,7 +1019,7 @@
         }, {
           name: 'cmdItalic',
           title: 'Italic',
-          btnText: 'Italic',
+          // btnText: 'Italic',
           hotkey: 'Ctrl+I',
           icon: {
             glyph: 'glyphicon glyphicon-italic',
@@ -1056,7 +1056,7 @@
         }, {
           name: 'cmdHeading',
           title: 'Heading',
-          btnText: "Heading",
+          // btnText: "Heading",
           hotkey: 'Ctrl+H',
           icon: {
             glyph: 'glyphicon glyphicon-header',
@@ -1102,7 +1102,7 @@
         data: [{
           name: 'cmdUrl',
           title: 'URL/Link',
-          btnText: 'URL/Link',
+          // btnText: 'URL/Link',
           hotkey: 'Ctrl+L',
           icon: {
             glyph: 'glyphicon glyphicon-link',
@@ -1139,7 +1139,7 @@
         }, {
           name: 'cmdImage',
           title: 'Image',
-          btnText: 'Image',
+          // btnText: 'Image',
           hotkey: 'Ctrl+G',
           icon: {
             glyph: 'glyphicon glyphicon-picture',
@@ -1183,7 +1183,7 @@
           name: 'cmdList',
           hotkey: 'Ctrl+U',
           title: 'Unordered List',
-          btnText: 'Unordered List',
+          // btnText: 'Unordered List',
           icon: {
             glyph: 'glyphicon glyphicon-list',
             fa: 'fa fa-list',
@@ -1244,7 +1244,7 @@
           name: 'cmdListO',
           hotkey: 'Ctrl+O',
           title: 'Ordered List',
-          btnText: 'Ordered List',
+          // btnText: 'Ordered List',
           icon: {
             glyph: 'glyphicon glyphicon-th-list',
             fa: 'fa fa-list-ol',
@@ -1306,7 +1306,7 @@
           name: 'cmdCode',
           hotkey: 'Ctrl+K',
           title: 'Code',
-          btnText: 'Code',
+          // btnText: 'Code',
           icon: {
             glyph: 'glyphicon glyphicon-asterisk',
             fa: 'fa fa-code',
@@ -1397,7 +1397,7 @@
           name: 'cmdQuote',
           hotkey: 'Ctrl+Q',
           title: 'Quote',
-          btnText: 'Quote',
+          // btnText: 'Quote',
           icon: {
             glyph: 'glyphicon glyphicon-comment',
             fa: 'fa fa-quote-left',
@@ -1455,7 +1455,7 @@
           toggle: true,
           hotkey: 'Ctrl+P',
           title: 'Preview',
-          btnText: 'Preview',
+          // btnText: 'Preview',
           btnClass: 'btn btn-primary btn-sm',
           icon: {
             glyph: 'glyphicon glyphicon-search',

--- a/app/assets/stylesheets/bootstrap-markdown.min.css
+++ b/app/assets/stylesheets/bootstrap-markdown.min.css
@@ -55,6 +55,7 @@
 .md-editor .md-controls {
   float: right;
   padding: 3px;
+  display: none; /* Element kann komplett weg */
 }
 
 .md-editor .md-controls .md-control {
@@ -67,7 +68,7 @@
   color: #333;
 }
 
-.md-fullscreen-mode #forum-usage, .md-fullscreen-mode .image-upload {
+.md-fullscreen-mode .image-upload {
   display:none;
 }
 

--- a/app/assets/stylesheets/bootstrap-markdown.min.css
+++ b/app/assets/stylesheets/bootstrap-markdown.min.css
@@ -13,8 +13,23 @@
 
 .md-editor>.md-header {
   margin: 0;
-  margin-bottom:1em;
+  background: transparent;
+  padding-left: .8em;
 }
+
+.btn-toolbar button, .btn-toolbar a {
+  background-color: #f5f5f5;
+  padding: 3px 6px;
+}
+
+.btn-toolbar button > .fa-question,
+.btn-toolbar button.forum-usage {
+  color: #c32e04;
+  background-color: #feebe6;
+}
+
+
+
 
 .md-editor>.md-preview {
   background: #fff;

--- a/app/assets/stylesheets/messages.css.scss
+++ b/app/assets/stylesheets/messages.css.scss
@@ -429,18 +429,6 @@ blockquote.show-quotes .unfold {
   }
 }
 
-.md-header #forum-usage {
-  margin: 3px -4px 0;
-  border-top: 5px solid white;
-  padding: .8em;
-  text-align: center;
-
-  a:last-child {
-    color: #3481CD;
-    &:hover, &:active, &:focus { color: #990909; }
-  }
-}
-
 #unfold-all {
   position:fixed;
   cursor:pointer;

--- a/app/assets/stylesheets/messages.css.scss
+++ b/app/assets/stylesheets/messages.css.scss
@@ -471,14 +471,14 @@ textarea.length-error, .message-character-count.length-error, .twitter-message-c
   padding:0;
   text-align:right;
   width:calc(99% + 2px); // 2px border
-  margin:auto;
-  margin-bottom:0.2em;
+  margin:-36px auto 8px;
 
   .message-character-count {
+    font-size: 14px;
+    line-height: 1.42857;
     background:#f5f5f5;
-    padding: 0.25em;
-    border-radius: 4px 4px 0 0;
-    border: 1px solid #D5D5D5;
+    padding: 3px 6px;
+    border-radius: 4px;
   }
 }
 

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -40,10 +40,6 @@ with_name ||= false
 </fieldset>
 
 <fieldset>
-  <p id="forum-usage"><%== t("messages.forum_usage",
-                             markdown_link: cf_link_to(t("messages.markdown"), 'http://markdown.de/syntax/index.html'),
-                             wiki_link: cf_link_to(t("messages.wiki"), 'https://wiki.selfhtml.org/'),
-                             help_link: cf_link_to(t("messages.help_with_formatting"), 'https://wiki.selfhtml.org/wiki/SELFHTML:Forum/Bedienung')) %></p>
   <div class="cf-cgroup cf-textarea-only">
     <div class="cntrls">
       <%= f.text_area :content, class: 'big', id: 'message_input', maxlength: 12288, value: f.object.to_txt, required: true %>


### PR DESCRIPTION
Die pixel sind bootstrap geschuldet. Der Hilfe-Link sollte auch ein button sein, sonst muss man mehr Aufwand treiben.