### PR TITLE
Unify error messages

### DIFF
--- a/app/assets/stylesheets/alerts.css.scss
+++ b/app/assets/stylesheets/alerts.css.scss
@@ -11,7 +11,7 @@
 
 .cf-alert {
   padding:1em;
-  margin: 0;
+  margin: 0 0 1em;
   border:1px solid transparent;
   border-radius:4px;
   box-shadow:0px 0px 6px #666;
@@ -51,7 +51,7 @@
   padding: 0px;
   cursor: pointer;
   background: none repeat scroll 0px 0px transparent;
-  border: 0px none;  
+  border: 0px none;
   font-size: 21px;
   font-weight: bold;
   line-height: 1;

--- a/app/controllers/synonyms_controller.rb
+++ b/app/controllers/synonyms_controller.rb
@@ -37,7 +37,7 @@ class SynonymsController < ApplicationController
 
     if @synonym.save
       audit(@synonym, 'create')
-      redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonym_created')
+      redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonyms.created')
     else
       render :new
     end
@@ -50,7 +50,7 @@ class SynonymsController < ApplicationController
   def update
     if @synonym.update_attributes(tag_synonym_params)
       audit(@synonym, 'update')
-      redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonym_updated')
+      redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonyms.updated')
     else
       render :edit
     end
@@ -59,7 +59,7 @@ class SynonymsController < ApplicationController
   def destroy
     @synonym.destroy
     audit(@synonym, 'destroy')
-    redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonym_destroyed')
+    redirect_to tag_url(current_forum.slug, @tag), notice: t('tags.synonyms.destroyed')
   end
 end
 

--- a/app/views/admin/badge_groups/_form.html.erb
+++ b/app/views/admin/badge_groups/_form.html.erb
@@ -1,15 +1,4 @@
-<% if @badge_group.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('admin.badge_groups.error_message',
-              count: @badge_group.errors.count) %></h2>
-
-    <ul>
-      <% @badge_group.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @badge_group, scope: 'admin.badge_groups' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/badge_groups/_form.html.erb
+++ b/app/views/admin/badge_groups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @badge_group, scope: 'admin.badge_groups' %>
+<%= render 'application/errors', object: @badge_group, scope: 'admin.badge_groups' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/badges/_form.html.erb
+++ b/app/views/admin/badges/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @badge, scope: 'admin.badges' %>
+<%= render 'application/errors', object: @badge, scope: 'admin.badges' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/badges/_form.html.erb
+++ b/app/views/admin/badges/_form.html.erb
@@ -1,14 +1,4 @@
-  <% if @badge.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('admin.badges.error_message', count: @badge.errors.count) %></h2>
-
-      <ul>
-        <% @badge.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= render 'errors', object: @badge, scope: 'admin.badges' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @event, scope: 'admin.events' %>
+<%= render 'application/errors', object: @event, scope: 'admin.events' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,14 +1,4 @@
-<% if @event.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('admin.events.error_message', count: @event.errors.count) %></h2>
-
-    <ul>
-      <% @event.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @event, scope: 'admin.events' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/forums/_form.html.erb
+++ b/app/views/admin/forums/_form.html.erb
@@ -1,7 +1,7 @@
 <% if @forum.errors.any? or @settings.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('admin.forums.error_message',
-              count: @forum.errors.count + @settings.errors.count) %></h2>
+  <div id="error_explanation" class="cf-error">
+    <h4><%= t('admin.forums.error_message',
+              count: @forum.errors.count + @settings.errors.count) %></h4>
 
     <ul>
       <% @forum.errors.full_messages.each do |msg| %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @group, scope: 'admin.groups' %>
+<%= render 'application/errors', object: @group, scope: 'admin.groups' %>
 
 <div class="cf-cgroup">
   <%= t.label :name %>

--- a/app/views/admin/groups/_form.html.erb
+++ b/app/views/admin/groups/_form.html.erb
@@ -1,15 +1,4 @@
-<% if @group.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('admin.groups.error_message', count: @group.errors.count) %></h2>
-
-    <ul>
-      <% @group.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
+<%= render 'errors', object: @group, scope: 'admin.groups' %>
 
 <div class="cf-cgroup">
   <%= t.label :name %>

--- a/app/views/admin/redirections/_form.html.erb
+++ b/app/views/admin/redirections/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @redirection, scope: 'admin.redirections' %>
+<%= render 'application/errors', object: @redirection, scope: 'admin.redirections' %>
 
 <div class="cf-cgroup">
   <%= f.label :path %>

--- a/app/views/admin/redirections/_form.html.erb
+++ b/app/views/admin/redirections/_form.html.erb
@@ -1,14 +1,4 @@
-<% if @redirection.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('admin.badges.error_message', count: @redirection.errors.count) %></h2>
-
-    <ul>
-      <% @redirection.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @redirection, scope: 'admin.redirections' %>
 
 <div class="cf-cgroup">
   <%= f.label :path %>

--- a/app/views/admin/search_sections/_form.html.erb
+++ b/app/views/admin/search_sections/_form.html.erb
@@ -1,14 +1,4 @@
-  <% if @search_section.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('admin.search_sections.error_message', count: @search_section.errors.count) %></h2>
-
-      <ul>
-        <% @search_section.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= render 'errors', object: @search_section, scope: 'admin.search_sections' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/search_sections/_form.html.erb
+++ b/app/views/admin/search_sections/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @search_section, scope: 'admin.search_sections' %>
+<%= render 'application/errors', object: @search_section, scope: 'admin.search_sections' %>
 
 <div class="cf-cgroup">
   <%= f.label :name %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @user, scope: 'admin.users' %>
+<%= render 'application/errors', object: @user, scope: 'admin.users' %>
 
 <div class="cf-cgroup">
   <%= f.label :username %>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,14 +1,4 @@
-<% if @user.errors.any? %>
-  <div id="error_explanation">
-    <h2><% t('admin.users.error_message', count: @user.errors.count) %>:</h2>
-
-    <ul>
-      <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @user, scope: 'admin.users' %>
 
 <div class="cf-cgroup">
   <%= f.label :username %>

--- a/app/views/application/_errors.html.erb
+++ b/app/views/application/_errors.html.erb
@@ -1,0 +1,10 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="cf-error">
+    <h4><%= t('error_message', count: object.errors.count, scope: scope) %></h4>
+    <ul>
+      <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/attendees/_form.html.erb
+++ b/app/views/attendees/_form.html.erb
@@ -1,14 +1,4 @@
-<% if @attendee.errors.any? %>
-  <div id="error_explanation">
-    <h2><%= t('events.attendees.error_message', count: @attendee.errors.count) %></h2>
-
-    <ul>
-      <% @attendee.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @attendee, scope: 'events.attendees' %>
 
 <% if current_user.blank? %>
   <div class="cf-cgroup">

--- a/app/views/attendees/_form.html.erb
+++ b/app/views/attendees/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @attendee, scope: 'events.attendees' %>
+<%= render 'application/errors', object: @attendee, scope: 'events.attendees' %>
 
 <% if current_user.blank? %>
   <div class="cf-cgroup">

--- a/app/views/cf_threads/_form.html.erb
+++ b/app/views/cf_threads/_form.html.erb
@@ -1,17 +1,6 @@
+<%= render 'errors', object: @thread.message, scope: 'messages' %>
+
 <%= form_for @thread, url: cf_threads_path(current_forum), html: {class: 'form-horizontal'} do |f| %>
-  <% if @thread.message.errors.any? %>
-    <div id="error_explanation" class="cf-error">
-      <h4><%= t('messages.error_message', count: @thread.message.errors.count) %></h4>
-
-      <ul>
-        <% @thread.message.errors.each do |k, msg| %>
-          <% next if k == :thread_id %>
-          <li><%= Message.human_attribute_name(k) %> <%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <% if current_forum.blank? %>
     <div class="cf-cgroup">
       <%= f.label :forum_id %>

--- a/app/views/cf_threads/_form.html.erb
+++ b/app/views/cf_threads/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @thread.message, scope: 'messages' %>
+<%= render 'application/errors', object: @thread.message, scope: 'messages' %>
 
 <%= form_for @thread, url: cf_threads_path(current_forum), html: {class: 'form-horizontal'} do |f| %>
   <% if current_forum.blank? %>

--- a/app/views/cites/_form.html.erb
+++ b/app/views/cites/_form.html.erb
@@ -1,14 +1,4 @@
-<% if @cite.errors.any? %>
-  <div id="error_explanation" class="cf-error">
-    <h4><%= t('cites.error_message', count: @cite.errors.count) %></h4>
-
-    <ul>
-      <% @cite.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
+<%= render 'errors', object: @cite, scope: 'cites' %>
 
 <fieldset>
   <div class="cf-cgroup">

--- a/app/views/cites/_form.html.erb
+++ b/app/views/cites/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @cite, scope: 'cites' %>
+<%= render 'application/errors', object: @cite, scope: 'cites' %>
 
 <fieldset>
   <div class="cf-cgroup">

--- a/app/views/close_vote/new.html.erb
+++ b/app/views/close_vote/new.html.erb
@@ -8,7 +8,7 @@ content_for :h1, t("messages.close_vote.close_message",
                    author: @message.author)
 %>
 
-<%= render 'errors', object: @close_vote, scope: 'messages.close_vote' %>
+<%= render 'application/errors', object: @close_vote, scope: 'messages.close_vote' %>
 
 <%= form_for(@close_vote, url: close_message_path(@thread, @message),
              html: {:class => 'form-horizontal'}, method: :put) do |f| %>

--- a/app/views/close_vote/new.html.erb
+++ b/app/views/close_vote/new.html.erb
@@ -8,17 +8,7 @@ content_for :h1, t("messages.close_vote.close_message",
                    author: @message.author)
 %>
 
-<% if @close_vote.errors.any? %>
-  <div id="error_explanation" class="cf-error">
-    <h4><%= t('messages.close_vote.error_message', count: @close_vote.errors.count) %></h4>
-
-      <ul>
-      <% @close_vote.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ul>
-    </div>
-<% end %>
+<%= render 'errors', object: @close_vote, scope: 'messages.close_vote' %>
 
 <%= form_for(@close_vote, url: close_message_path(@thread, @message),
              html: {:class => 'form-horizontal'}, method: :put) do |f| %>

--- a/app/views/close_vote/new_open.html.erb
+++ b/app/views/close_vote/new_open.html.erb
@@ -7,17 +7,7 @@ content_for :h1, t("messages.close_vote.open_message",
                    author: @message.author)
 %>
 
-<% if @open_vote.errors.any? %>
-  <div id="error_explanation" class="cf-error">
-    <h4><%= t('messages.close_vote.error_message', count: @open_vote.errors.count) %></h4>
-
-      <ul>
-      <% @open_vote.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ul>
-    </div>
-<% end %>
+<%= render 'errors', object: @open_vote, scope: 'messages.close_vote' %>
 
 <%= form_for(@open_vote, url: open_message_path(@thread, @message),
              html: {:class => 'form-horizontal'}, method: :put) do |f| %>

--- a/app/views/close_vote/new_open.html.erb
+++ b/app/views/close_vote/new_open.html.erb
@@ -7,7 +7,7 @@ content_for :h1, t("messages.close_vote.open_message",
                    author: @message.author)
 %>
 
-<%= render 'errors', object: @open_vote, scope: 'messages.close_vote' %>
+<%= render 'application/errors', object: @open_vote, scope: 'messages.close_vote' %>
 
 <%= form_for(@open_vote, url: open_message_path(@thread, @message),
              html: {:class => 'form-horizontal'}, method: :put) do |f| %>

--- a/app/views/mails/_form.html.erb
+++ b/app/views/mails/_form.html.erb
@@ -1,4 +1,4 @@
-  <%= render 'errors', object: @mail, scope: 'mails' %>
+  <%= render 'application/errors', object: @mail, scope: 'mails' %>
 
   <%= f.hidden_field :thread_id %>
 

--- a/app/views/mails/_form.html.erb
+++ b/app/views/mails/_form.html.erb
@@ -1,14 +1,4 @@
-  <% if @mail.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('mails.error_message', count: @mail.errors.count) %></h2>
-
-      <ul>
-      <% @mail.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'errors', object: @mail, scope: 'mails' %>
 
   <%= f.hidden_field :thread_id %>
 

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -15,7 +15,7 @@ content_for :body_classes, 'messages edit forum-' + (current_forum.try(:slug) ||
   </article>
 <% end %>
 
-<%= render 'errors', object: @message, scope: 'messages' %>
+<%= render 'application/errors', object: @message, scope: 'messages' %>
 
 <%= form_for(@message, url: edit_message_path(@thread, @message),
              html: {class: 'form-horizontal'}) do |f| %>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -15,20 +15,10 @@ content_for :body_classes, 'messages edit forum-' + (current_forum.try(:slug) ||
   </article>
 <% end %>
 
+<%= render 'errors', object: @message, scope: 'messages' %>
+
 <%= form_for(@message, url: edit_message_path(@thread, @message),
              html: {class: 'form-horizontal'}) do |f| %>
-  <% if @message.errors.any? %>
-    <div id="error_explanation" class="cf-error">
-      <h4><%= t('messages.error_message', count: @message.errors.count) %></h4>
-
-      <ul>
-        <% @message.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <%= render "form", f: f, with_name: true, tags: @tags, message: @message %>
 
   <% if @edit and (current_user.try(:admin?) and @message.format == 'markdown') %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -13,19 +13,9 @@ content_for :body_classes, 'messages new forum-' + (current_forum.try(:slug) || 
   <% end %>
 </article>
 
+<%= render 'errors', object: @message, scope: 'messages' %>
+
 <%= form_for @message, url: message_path_wo_anchor(@thread, @parent), html: {class: 'form-horizontal answer-form'} do |f| %>
-  <% if @message.errors.any? %>
-    <div id="error_explanation" class="cf-error">
-      <h4><%= t('messages.error_message', count: @message.errors.count) %></h4>
-
-      <ul>
-        <% @message.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
   <%= render "form", f: f, tags: @tags, message: @message %>
 
   <%= render 'post_notes' %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -13,7 +13,7 @@ content_for :body_classes, 'messages new forum-' + (current_forum.try(:slug) || 
   <% end %>
 </article>
 
-<%= render 'errors', object: @message, scope: 'messages' %>
+<%= render 'application/errors', object: @message, scope: 'messages' %>
 
 <%= form_for @message, url: message_path_wo_anchor(@thread, @parent), html: {class: 'form-horizontal answer-form'} do |f| %>
   <%= render "form", f: f, tags: @tags, message: @message %>

--- a/app/views/synonyms/_form.html.erb
+++ b/app/views/synonyms/_form.html.erb
@@ -1,14 +1,4 @@
-  <% if @synonym.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('tags.error_message_synonym') %></h2>
-
-      <ul>
-        <% @synonym.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= render 'errors', object: @synonym, scope: 'tags.synonyms' %>
 
 <div class="cf-cgroup">
   <%= f.label :synonym %>

--- a/app/views/synonyms/_form.html.erb
+++ b/app/views/synonyms/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @synonym, scope: 'tags.synonyms' %>
+<%= render 'application/errors', object: @synonym, scope: 'tags.synonyms' %>
 
 <div class="cf-cgroup">
   <%= f.label :synonym %>

--- a/app/views/synonyms/edit.html.erb
+++ b/app/views/synonyms/edit.html.erb
@@ -1,6 +1,6 @@
 <%
-content_for :title, t('tags.edit_tag_synonym', name: @tag.tag_name, synonym: @synonym.synonym)
-content_for :h1, t('tags.edit_tag_synonym', name: @tag.tag_name, synonym: @synonym.synonym)
+content_for :title, t('tags.synonyms.edit_tag_synonym', name: @tag.tag_name, synonym: @synonym.synonym)
+content_for :h1, t('tags.synonyms.edit_tag_synonym', name: @tag.tag_name, synonym: @synonym.synonym)
 %>
 
 <%= form_for @synonym, url: tag_synonym_path(current_forum.slug, @tag, @synonym), html: {class: 'form-horizontal'} do |f| %>

--- a/app/views/synonyms/new.html.erb
+++ b/app/views/synonyms/new.html.erb
@@ -1,6 +1,6 @@
 <%
-content_for :title, t('tags.new_tag_synonym_for_tag', tag: @tag.tag_name)
-content_for :h1, t('tags.new_tag_synonym_for_tag', tag: @tag.tag_name)
+content_for :title, t('tags.synonyms.new_tag_synonym_for_tag', tag: @tag.tag_name)
+content_for :h1, t('tags.synonyms.new_tag_synonym_for_tag', tag: @tag.tag_name)
 %>
 
 <%= form_for @synonym , url: tag_synonyms_path(current_forum.slug, @tag), html: {class: 'form-horizontal'} do |f| %>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,14 +1,4 @@
-  <% if @tag.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= t('tags.error_message') %></h2>
-
-      <ul>
-        <% @tag.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= render 'errors', object: @tag, scope: 'tags' %>
 
 <div class="cf-cgroup">
   <%= f.label :tag_name %>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render 'errors', object: @tag, scope: 'tags' %>
+<%= render 'application/errors', object: @tag, scope: 'tags' %>
 
 <div class="cf-cgroup">
   <%= f.label :tag_name %>

--- a/app/views/tags/_subnav.html.erb
+++ b/app/views/tags/_subnav.html.erb
@@ -5,7 +5,7 @@
     <% end %>
 
     <% if may?(Badge::CREATE_TAG_SYNONYM) and @tag and @tag.tag_id %>
-      <li<% if action_name == 'new_synonym' %> class="active"<% end %>><%= cf_link_to t('tags.new_tag_synonym'), new_tag_synonym_path(current_forum.slug, @tag) %></li>
+      <li<% if action_name == 'new_synonym' %> class="active"<% end %>><%= cf_link_to t('tags.synonyms.new_tag_synonym'), new_tag_synonym_path(current_forum.slug, @tag) %></li>
     <% end %>
 
     <% if current_user and current_user.admin and @tag and @tag.tag_id %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -5,10 +5,10 @@ content_for(:body_id, "tags-" + @tag.slug)
 content_for(:body_classes, 'tags show forum-' + (current_forum.try(:slug) || 'all') + ' tag-' + @tag.slug)
 %>
 
-<h2><%= t('tags.synonyms') %>:</h2>
+<h2><%= t('tags.synonyms.synonyms') %>:</h2>
 
 <% if @tag.synonyms.blank? %>
-  <p><%= t('tags.no_synonyms') %></p>
+  <p><%= t('tags.synonyms.no_synonyms') %></p>
 <% else %>
   <ul class="cf-tags-list">
     <% @tag.synonyms.each do |syn| %>

--- a/app/views/users/_user_information.html.erb
+++ b/app/views/users/_user_information.html.erb
@@ -1,4 +1,4 @@
-  <%= render 'errors', object: @user, scope: 'users' %>
+  <%= render 'application/errors', object: @user, scope: 'users' %>
 
   <fieldset class="cf-tab-pane active" id="user-data">
     <legend><%= t('users.user_information') %></legend>

--- a/app/views/users/_user_information.html.erb
+++ b/app/views/users/_user_information.html.erb
@@ -1,14 +1,4 @@
-  <% if @user.errors.any? %>
-    <div id="error_explanation" class="cf-error">
-      <h4><%= t('users.error_message', count: @user.errors.count) %></h4>
-
-      <ul>
-      <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+  <%= render 'errors', object: @user, scope: 'users' %>
 
   <fieldset class="cf-tab-pane active" id="user-data">
     <legend><%= t('users.user_information') %></legend>

--- a/config/locales/tags.de.yml
+++ b/config/locales/tags.de.yml
@@ -3,29 +3,35 @@ de:
     tags: Tags
     new_tag: Neues Tag erstellen
     edit_tag: Tag „%{name}“ bearbeiten
-    edit_tag_synonym: "Tag „%{name}“: Synonym „%{synonym}“ bearbeiten"
-    error_message: "Aufgrund folgender Fehler konnte das Tag nicht gespeichert werden:"
-    error_message_synonym: "Aufgrund folgender Fehler konnte das Synonym nicht gespeichert werden:"
+    error_message:
+      other: "%{count} Fehler verhinderten, dass dieses Tag gespeichert werden konnte:"
+      one: "%{count} Fehler verhindert, dass dieses Tag gespeichert werden konnte:"
     delete_tag: Tag „%{name}“ löschen
     do_delete_tag: Tag löschen
     do_edit_tag: Tag bearbeiten
-    new_tag_synonym: Neues Synonym erstellen
-    new_tag_synonym_for_tag: "Tag „%{tag}“: Neues Synonym erstellen"
     tags_for_forum: "%{forum}: Tags"
     merge: Tag zusammenführen
     not_used_for_suggestions: Das Tag wird nicht für Vorschläge benutzt.
     existing_tag_will_be_merged_to: "Das Tag „%{tag}“ wird gelöscht und dem oben ausgewählten als Synonym hinzugefügt. Alle Beiträge mit dem Tag „%{tag}“ werden dabei dem oben ausgewählten Tag zugeordnet. "
 
-    no_synonyms: Bisher sind keine Synonyme bekannt.
     no_messages: Bisher sind keine Beiträge mit diesem Tag geschrieben worden.
-    synonyms: Synonyme
 
     created: Das Tag wurde erfolgreich erstellt.
-    synonym_created: Das Synonym wurde erfolgreich erstellt.
     updated: Das Tag wurde erfolgreich geändert.
-    synonym_updated: Das Synonym wurde erfolgreich geändert.
     destroyed: Das Tag wurde erfolgreich gelöscht.
-    synonym_destroyed: Das Synonym wurde erfolgreich gelöscht.
     merged: Die Tags wurden erfolgreich zusammengeführt.
 
     tag_has_messages: Das Tag ist noch Nachrichten zugeordnet. Es kann nicht gelöscht werden.
+
+    synonyms:
+      synonyms: Synonyme
+      no_synonyms: Bisher sind keine Synonyme bekannt.
+      edit_tag_synonym: "Tag „%{name}“: Synonym „%{synonym}“ bearbeiten"
+      new_tag_synonym: Neues Synonym erstellen
+      new_tag_synonym_for_tag: "Tag „%{tag}“: Neues Synonym erstellen"
+      created: Das Synonym wurde erfolgreich erstellt.
+      updated: Das Synonym wurde erfolgreich geändert.
+      destroyed: Das Synonym wurde erfolgreich gelöscht.
+      error_message:
+        other: "%{count} Fehler verhinderten, dass dieses Synonym gespeichert werden konnte:"
+        one: "%{count} Fehler verhindert, dass dieses Synonym gespeichert werden konnte:"


### PR DESCRIPTION
Some error messages looked different than others, especially in admin. This unifies all error messages by using a partial.

`app/views/admin/forums/_form.html.erb` and `app/views/messages/split_thread/edit.html.erb` do not use the partial because they are a bit more complex.