### PR TITLE
Replaces string delimiters and does some formatting.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -104,12 +104,17 @@ $(function() {
 
 cforum.alert = {
   alert: function(text, type) {
-    var alrt = $("<div class=\"" + type + " cf-alert\"><button type=\"button\" class=\"close\" data-dismiss=\"cf-alert\" aria-label=\"Close\"><span aria-hidden=\"true\">&times;</span></button></div>");
-    alrt.text(text);
-    $("#alerts-container").append(alrt);
+    var alert = $('<div class="' + type + ' cf-alert"><button type="button" class="close" data-dismiss="cf-alert" aria-label="Close"><span aria-hidden="true">&times;</span></button></div>');
+    alert.text(text);
+
+    $('#alerts-container').append(alert);
     setDismissHandlers();
 
-    window.setTimeout(function () { alrt.fadeOut('fast', function() { $(this).remove(); }); }, 3000);
+    window.setTimeout(function () {
+      alert.fadeOut('fast', function() {
+        $(this).remove();
+      });
+    }, 3000);
   },
 
   error: function(text) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,9 +23,10 @@
 
 function hasLocalstorage() {
   try {
-    return 'localStorage' in window && window['localStorage'] !== null;
+    localStorage.setItem('test', 'test'), localStorage.removeItem('test');
+    return true;
   }
-  catch (e) {
+  catch (exception) {
     return false;
   }
 }


### PR DESCRIPTION
There is no need to escape double quotes when using single quotes for a string literal, which you do most of the time anyway. Furthermore, alert is neither a reserved word, nor are any variables shadowed other than the global function of the same name. So, for the sake of readability...

For the same reason I introduced some line breaks.

I would also suggest to use a template element instead of constructing markup within the script like this. I'd have to look if this is a repeated pattern, though. If it is, I think its definitely worth to include a polyfill for the template element and only keep the non static parts in the script.